### PR TITLE
chore: release v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # mantle-viem
 
+## 0.1.1
+
+### Patch Changes
+
+- Republish to ship the compiled output omitted from 0.1.0's npm package. 0.1.0 shipped a stale `dist/` (built before the migrated-withdrawal / latest-output work), so `buildMigratedWithdrawal` was missing and `getL2Output`'s `strategy` parameter and the `l1CrossDomainMessenger` chain config were absent at runtime despite being documented. No source changes.
+
 ## 0.1.0
 
 ### Minor Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@mantleio/viem",
-	"version": "0.1.0",
+	"version": "0.1.1",
 	"description": "Viem extension for the Mantle network — L1 ↔ L2 deposits, withdrawals, and fee estimation",
 	"keywords": [
 		"mantle",


### PR DESCRIPTION
Republish complete dist — 0.1.0 shipped a stale build missing buildMigratedWithdrawal / getL2Output strategy / l1CrossDomainMessenger. No source changes.